### PR TITLE
Remove comment on format string literals

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,2 @@
-// format strings are short hand-written literals ("yyyy-MM-dd")
 // cap the length so a bug or bad input can't make tokenize() do unbounded work
 export const MAX_FORMAT_LENGTH = 1000;


### PR DESCRIPTION
also noticed that format string comment in constants.ts ok to remove? file be cleaner without it.