### PR TITLE
parse throws on mixed 24h/12h tokens now

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -109,6 +109,12 @@ function resolveYear(fields: Fields): number | undefined {
 }
 
 function resolveHour(fields: Fields, formatStr: string): number | undefined {
+  if (fields.hour !== undefined && fields.hour12 !== undefined) {
+    throw new Error(
+      `temporal-fmt: format string "${formatStr}" mixes a 24-hour token ("HH"/"H") with a ` +
+      `12-hour token ("hh"/"h"). Pick one or the other — parse() won't guess which is authoritative.`
+    );
+  }
   if (fields.hour !== undefined) return fields.hour;
   if (fields.hour12 !== undefined) {
     if (fields.isPM === undefined) {

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -56,6 +56,16 @@ test('12-hour token without an "a" token throws', () => {
   assert.throws(() => parse('yyyy-MM-dd h:mm', '2026-08-04 3:45'));
 });
 
+test('mixing a 24-hour token with a 12-hour token throws, even when the values agree', () => {
+  // HH says 15, h/a says 3 PM — same instant, still rejected: parse() doesn't
+  // pick a winner between two hour tokens that shouldn't both be there.
+  assert.throws(() => parse('HH h a', '15 3 PM'));
+});
+
+test('mixing a 24-hour token with a 12-hour token throws when the values disagree', () => {
+  assert.throws(() => parse('HH h a', '15 9 AM'));
+});
+
 test('locale month name reverse lookup, default en-US', () => {
   const result = parse('MMMM d, yyyy', 'August 4, 2026');
   assert.equal(result.toString(), Temporal.PlainDate.from('2026-08-04').toString());


### PR DESCRIPTION
saw the open question on the wiki about resolveHour just picking HH over hh/a when both show up in a format string lol. figured throwing makes more sense since thats literally how parse handles every other messed up input so quietly picking a winner between two hour tokens felt kinda janky ngl.

i made it so it throws now if both fields.hour and fields.hour12 are set, doesnt even matter if the values agree or not having both token types in there at all is the problem not just when they clash.

added 2 tests, one where they agree and one where they dont, both throw either way.